### PR TITLE
Fix Node.js v10 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports = (opts = {}) => {
     teardown: async function teardown () {
       try {
         log('Tearing down fixtures')
-        await fs.rmdir(TMP, { recursive: true })
+        await fs.remove(TMP)
       } catch (e) {
         // Ignore errors removing if it doesnt exist
         if (e.code !== 'ENOENT') {


### PR DESCRIPTION
Hey @wesleytodd!

I took a look on broken tests on v10 and found that problem is with `fs.rmdir()`. In v10 it has different API ([v10](https://nodejs.org/docs/latest-v10.x/api/fs.html#fs_fs_rmdir_path_callback), [v14](https://nodejs.org/dist/latest-v14.x/docs/api/fs.html#fs_fs_rmdir_path_options_callback))

So I changed it to `fs.remove` from `node-fs-extra` package.